### PR TITLE
Get rid of VSTHRD010 warning in more projects

### DIFF
--- a/src/Ankh.Package/AnkhEditorFactories.cs
+++ b/src/Ankh.Package/AnkhEditorFactories.cs
@@ -154,6 +154,8 @@ namespace Ankh.VSPackage
 
         public override int CreateEditorInstance(uint grfCreateDoc, string pszMkDocument, string pszPhysicalView, IVsHierarchy pvHier, uint itemid, IntPtr punkDocDataExisting, out IntPtr ppunkDocView, out IntPtr ppunkDocData, out string pbstrEditorCaption, out Guid pguidCmdUI, out int pgrfCDW)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (_forms.Count == 0)
             {
                 ppunkDocView = IntPtr.Zero;

--- a/src/Ankh.Package/AnkhSvnPackage.About.cs
+++ b/src/Ankh.Package/AnkhSvnPackage.About.cs
@@ -107,6 +107,8 @@ namespace Ankh.VSPackage
 
         public int OfficialName(out string pbstrName)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (InCommandLineMode)
             {
                 // We are running in /setup. The text is cached for the about box

--- a/src/Ankh.Package/AnkhSvnPackage.OleComponent.cs
+++ b/src/Ankh.Package/AnkhSvnPackage.OleComponent.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Text;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
 using System.Runtime.InteropServices;
 using Ankh.UI;
 using Ankh.VS;
@@ -30,6 +31,8 @@ namespace Ankh.VSPackage
         uint _componentId;
         void RegisterAsOleComponent()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (_componentId != 0)
                 return;
 

--- a/src/Ankh.Package/AnkhSvnPackage.SolutionProperties.cs
+++ b/src/Ankh.Package/AnkhSvnPackage.SolutionProperties.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Ankh.Scc;
 using Ankh.Scc.Native;
@@ -51,8 +52,8 @@ namespace Ankh.VSPackage
             get { return _scc ?? (_scc = GetService<IAnkhSccService>()); }
         }
 
-        // Global note: 
-        // The same trick we do here for the solution (loading the package when encountering a solution property) 
+        // Global note:
+        // The same trick we do here for the solution (loading the package when encountering a solution property)
         // can be done on several project types using IVsProjectStartupServices
         public int QuerySaveSolutionProps(IVsHierarchy pHierarchy, VSQUERYSAVESLNPROPS[] pqsspSave)
         {
@@ -102,13 +103,15 @@ namespace Ankh.VSPackage
 
         public int SaveSolutionProps(IVsHierarchy pHierarchy, IVsSolutionPersistence pPersistence)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             try
             {
                 int hr = VSErr.S_OK;
 
                 // This function gets called by the shell after QuerySaveSolutionProps returned QSP_HasDirtyProps
 
-                // The package will pass in the key under which it wants to save its properties, 
+                // The package will pass in the key under which it wants to save its properties,
                 // and the IDE will call back on WriteSolutionProps
 
                 // The properties will be saved in the Pre-Load section
@@ -232,6 +235,8 @@ namespace Ankh.VSPackage
 
         public int LoadUserOptions(IVsSolutionPersistence pPersistence, uint grfLoadOpts)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if ((grfLoadOpts & (uint)__VSLOADUSEROPTS.LUO_OPENEDDSW) != 0)
             {
                 return VSErr.S_OK; // We only know .suo; let's ignore old style projects
@@ -263,6 +268,8 @@ namespace Ankh.VSPackage
 
         public bool ForceLoadUserSettings(string streamName)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             IVsSolutionPersistence persistence = GetService<IVsSolutionPersistence>(typeof(SVsSolutionPersistence));
             if (persistence == null)
                 return false;
@@ -339,6 +346,8 @@ namespace Ankh.VSPackage
 
         public int SaveUserOptions([In] IVsSolutionPersistence pPersistence)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             try
             {
                 IAnkhSccService scc = GetService<IAnkhSccService>();

--- a/src/Ankh.Package/AnkhSvnPackage.ToolWindows.cs
+++ b/src/Ankh.Package/AnkhSvnPackage.ToolWindows.cs
@@ -54,6 +54,7 @@ namespace Ankh.VSPackage
     {
         public void ShowToolWindow(AnkhToolWindow window)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
             ShowToolWindow(window, 0, true);
         }
 
@@ -78,6 +79,8 @@ namespace Ankh.VSPackage
 
         public void ShowToolWindow(AnkhToolWindow toolWindow, int id, bool create)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             ToolWindowPane pane = FindToolWindow(GetPaneType(toolWindow), id, create);
 
             IVsWindowFrame frame = pane.Frame as IVsWindowFrame;
@@ -91,6 +94,8 @@ namespace Ankh.VSPackage
 
         public void CloseToolWindow(AnkhToolWindow toolWindow, int id, FrameCloseMode close)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             ToolWindowPane pane = FindToolWindow(GetPaneType(toolWindow), id, false);
 
             if (pane == null)
@@ -162,7 +167,11 @@ namespace Ankh.VSPackage
 
         public IVsWindowFrame Frame
         {
-            get { return ((IVsWindowFrame)_pane.Frame); }
+            get
+            {
+                ThreadHelper.ThrowIfNotOnUIThread();
+                return ((IVsWindowFrame)_pane.Frame);
+            }
         }
 
         public IVsWindowPane Pane
@@ -275,6 +284,8 @@ namespace Ankh.VSPackage
 
         public int Exec(ref Guid pguidCmdGroup, uint nCmdID, uint nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             foreach (IOleCommandTarget target in _targets)
             {
                 int hr = target.Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut);
@@ -293,6 +304,8 @@ namespace Ankh.VSPackage
 
         public int QueryStatus(ref Guid pguidCmdGroup, uint cCmds, OLECMD[] prgCmds, IntPtr pCmdText)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             foreach (IOleCommandTarget target in _targets)
             {
                 int hr = target.QueryStatus(ref pguidCmdGroup, cCmds, prgCmds, pCmdText);
@@ -320,18 +333,36 @@ namespace Ankh.VSPackage
 
         public Guid KeyboardContext
         {
-            get { return GetGuid(__VSFPROPID.VSFPROPID_InheritKeyBindings); }
-            set { SetGuid(__VSFPROPID.VSFPROPID_InheritKeyBindings, value); }
+            get
+            {
+                ThreadHelper.ThrowIfNotOnUIThread();
+                return GetGuid(__VSFPROPID.VSFPROPID_InheritKeyBindings);
+            }
+            set
+            {
+                ThreadHelper.ThrowIfNotOnUIThread();
+                SetGuid(__VSFPROPID.VSFPROPID_InheritKeyBindings, value);
+            }
         }
 
         public Guid CommandContext
         {
-            get { return GetGuid(__VSFPROPID.VSFPROPID_CmdUIGuid); }
-            set { SetGuid(__VSFPROPID.VSFPROPID_CmdUIGuid, value); }
+            get
+            {
+                ThreadHelper.ThrowIfNotOnUIThread();
+                return GetGuid(__VSFPROPID.VSFPROPID_CmdUIGuid);
+            }
+            set
+            {
+                ThreadHelper.ThrowIfNotOnUIThread();
+                SetGuid(__VSFPROPID.VSFPROPID_CmdUIGuid, value);
+            }
         }
 
         private Guid GetGuid(__VSFPROPID id)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             Guid gResult;
             if (VSErr.Succeeded(Frame.GetGuidProperty((int)id, out gResult)))
                 return gResult;
@@ -341,6 +372,8 @@ namespace Ankh.VSPackage
 
         private void SetGuid(__VSFPROPID id, Guid value)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             Marshal.ThrowExceptionForHR(Frame.SetGuidProperty((int)id, ref value));
         }
 
@@ -353,6 +386,8 @@ namespace Ankh.VSPackage
         {
             get
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
+
                 IVsWindowFrame frame = Frame;
                 if (frame != null)
                 {
@@ -506,6 +541,8 @@ namespace Ankh.VSPackage
 
         public override void OnToolBarAdded()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             base.OnToolBarAdded();
 
             if (ExtraToolBarId != AnkhToolBar.None)
@@ -570,16 +607,19 @@ namespace Ankh.VSPackage
 
         public int OnDockableChange(int fDockable)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
             return OnDockableChange(fDockable, 0, 0, 0, 0);
         }
 
         public int OnMove()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
             return OnMove(0, 0, 0, 0);
         }
 
         public int OnSize()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
             return OnSize(0, 0, 0, 0);
         }
 

--- a/src/Ankh.Package/AnkhSvnPackage.cs
+++ b/src/Ankh.Package/AnkhSvnPackage.cs
@@ -139,6 +139,8 @@ namespace Ankh.VSPackage
 
         void InitializeRuntime()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             _runtime.PreLoad();
 
             IServiceContainer container = GetService<IServiceContainer>();
@@ -162,6 +164,8 @@ namespace Ankh.VSPackage
 
         private void NotifyLoaded(bool started)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             // We set the user context AnkhLoadCompleted active when we are loaded
             // This event can be used to trigger loading other packages that depend on AnkhSVN
             //
@@ -200,6 +204,8 @@ namespace Ankh.VSPackage
         {
             get
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
+
                 if (!_inCommandLineMode.HasValue)
                 {
                     IVsShell shell = (IVsShell)GetService(typeof(SVsShell));
@@ -226,6 +232,8 @@ namespace Ankh.VSPackage
 
         public T QueryService<T>(Guid serviceGuid) where T : class
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             IOleServiceProvider sp = GetService<IOleServiceProvider>();
             IntPtr handle;
 

--- a/src/Ankh.Package/OptionPages/SolutionSettingsPage.cs
+++ b/src/Ankh.Package/OptionPages/SolutionSettingsPage.cs
@@ -84,7 +84,9 @@ namespace Ankh.VSPackage.OptionPages
 
 		public int TranslateAccelerator(MSG[] pMsg)
 		{
-			if (pMsg == null)
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (pMsg == null)
 				return VSErr.E_POINTER;
 
 			Message message = Message.Create(pMsg[0].hwnd, (int)pMsg[0].message, pMsg[0].wParam, pMsg[0].lParam);
@@ -93,10 +95,10 @@ namespace Ankh.VSPackage.OptionPages
 
 			if (control != null && control.PreProcessMessage(ref message))
 				return VSErr.S_OK;
-			
+
 			if (Site != null)
 				return Site.TranslateAccelerator(pMsg);
-			
+
 			return VSErr.S_OK;
 		}
 
@@ -113,7 +115,8 @@ namespace Ankh.VSPackage.OptionPages
 
 		void IPropertyPage2.Apply()
 		{
-			Apply();
+            ThreadHelper.ThrowIfNotOnUIThread();
+            Apply();
 		}
 
 		#endregion

--- a/src/Ankh.UI/Annotate/AnnotateService.cs
+++ b/src/Ankh.UI/Annotate/AnnotateService.cs
@@ -56,6 +56,8 @@ namespace Ankh.UI.Annotate
                               SvnIgnoreSpacing ignoreSpacing,
                               bool             retrieveMergeInfo )
         {
+            ThreadHelper.ThrowIfNotOnUIThread() ;
+
             // There are two SVN related operations:
             // [1] Getting the file at revisionEnd, which will be displayed in the editor
             // [2] Getting the blame information, which will be displayed in the margin

--- a/src/Ankh.UI/PendingChanges/Commits/PendingCommitsView.cs
+++ b/src/Ankh.UI/PendingChanges/Commits/PendingCommitsView.cs
@@ -27,6 +27,7 @@ using Ankh.Scc;
 using Ankh.Selection;
 using Ankh.UI.VSSelectionControls;
 using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Ankh.UI.PendingChanges.Commits
@@ -251,6 +252,8 @@ namespace Ankh.UI.PendingChanges.Commits
         IVsUIShell _shell;
         protected override void OnItemChecked(ItemCheckedEventArgs e)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             base.OnItemChecked(e);
 
             if (_shell == null)

--- a/src/Ankh.UI/PendingChanges/PendingChangesToolControl.cs
+++ b/src/Ankh.UI/PendingChanges/PendingChangesToolControl.cs
@@ -22,6 +22,7 @@ using System.Data;
 using System.Text;
 using System.Windows.Forms;
 using Ankh.UI.Services;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Ankh.Commands;
 using Microsoft.VisualStudio;
@@ -281,6 +282,8 @@ namespace Ankh.UI.PendingChanges
         static bool _vertical;
         protected override void OnFrameSize(FrameEventArgs e)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             Size sz = e.Location.Size;
 
             if (sz.Height > 50 && sz.Width > 50)
@@ -307,6 +310,8 @@ namespace Ankh.UI.PendingChanges
 
         private void ChangeOrientation()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (_vertical)
                 pendingChangesTabs.Dock = DockStyle.Bottom;
             else

--- a/src/Ankh.UI/PendingChanges/PendingCommitsPage.cs
+++ b/src/Ankh.UI/PendingChanges/PendingCommitsPage.cs
@@ -35,7 +35,7 @@ namespace Ankh.UI.PendingChanges
     partial class PendingCommitsPage : PendingChangesPage
     {
         PendingCommitsView pendingCommits;
-        IPendingChangeControl pendingChangeControl;
+        IPendingChangeControl pendingChangeControl = null ;
         IPendingChangeUI _ui;
 
         public PendingCommitsPage()
@@ -172,7 +172,7 @@ namespace Ankh.UI.PendingChanges
         }
 
         IPendingChangesManager _manager;
-        
+
         private void HookList()
         {
             if (_manager != null || Context == null)

--- a/src/Ankh.UI/SvnInfoGrid/Commands/SvnInfoTbCommands.cs
+++ b/src/Ankh.UI/SvnInfoGrid/Commands/SvnInfoTbCommands.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using Ankh.Commands;
 using System.Windows.Forms;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Ankh.UI.SvnInfoGrid.Commands
@@ -38,6 +39,8 @@ namespace Ankh.UI.SvnInfoGrid.Commands
 
         public void OnExecute(CommandEventArgs e)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (_control == null)
                 return; // Can never happen as update already checked this
 

--- a/src/Ankh.VS.IntegrationTest/IntegrationTest-Library/DialogboxPurger.cs
+++ b/src/Ankh.VS.IntegrationTest/IntegrationTest-Library/DialogboxPurger.cs
@@ -150,6 +150,8 @@ namespace Microsoft.VsSDK.IntegrationTestLibrary
         /// </summary>
         internal void Start()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             // We ask for the uishell here since we cannot do that on the therad that we will spawn.
             IVsUIShell uiShell = Package.GetGlobalService(typeof(SVsUIShell)) as IVsUIShell;
 
@@ -194,7 +196,7 @@ namespace Microsoft.VsSDK.IntegrationTestLibrary
             {
                 lock (Mutex)
                 {
-                    // Set the exit thread to true. Next time the thread will kill itselfes if it sees 
+                    // Set the exit thread to true. Next time the thread will kill itselfes if it sees
                     this.exitThread = true;
                 }
 
@@ -206,10 +208,12 @@ namespace Microsoft.VsSDK.IntegrationTestLibrary
         }
 
         /// <summary>
-        /// This is the thread method. 
+        /// This is the thread method.
         /// </summary>
         private void HandleDialogBoxes()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             // No synchronization numberOfDialogsToWaitFor since it is readonly
             IntPtr[] hwnds = new IntPtr[this.numberOfDialogsToWaitFor];
             bool[] dialogBoxCloseResults = new bool[this.numberOfDialogsToWaitFor];

--- a/src/Ankh.VS.IntegrationTest/IntegrationTest-Library/Utils.cs
+++ b/src/Ankh.VS.IntegrationTest/IntegrationTest-Library/Utils.cs
@@ -74,7 +74,7 @@ namespace Microsoft.VsSDK.IntegrationTestLibrary
             return result;
         }
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="embeddedResourceName"></param>
         /// <param name="baseFileName"></param>
@@ -186,7 +186,7 @@ namespace Microsoft.VsSDK.IntegrationTestLibrary
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="directory"></param>
         /// <param name="baseFileName"></param>
@@ -226,6 +226,8 @@ namespace Microsoft.VsSDK.IntegrationTestLibrary
         /// <param name="solutionName">Name of new solution.</param>
         public void CreateEmptySolution(string directory, string solutionName)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             CloseCurrentSolution(__VSSLNSAVEOPTIONS.SLNSAVEOPT_NoSave);
 
             string solutionDirectory = GetNewDirectoryName(directory, solutionName);
@@ -240,6 +242,8 @@ namespace Microsoft.VsSDK.IntegrationTestLibrary
 
         public void CloseCurrentSolution(__VSSLNSAVEOPTIONS saveoptions)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             // Get solution service
             IVsSolution solutionService = (IVsSolution)VsIdeTestHostContext.ServiceProvider.GetService(typeof(IVsSolution));
 
@@ -249,6 +253,8 @@ namespace Microsoft.VsSDK.IntegrationTestLibrary
 
         public void ForceSaveSolution()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             // Get solution service
             IVsSolution solutionService = (IVsSolution)VsIdeTestHostContext.ServiceProvider.GetService(typeof(IVsSolution));
 
@@ -262,6 +268,8 @@ namespace Microsoft.VsSDK.IntegrationTestLibrary
         /// <returns></returns>
         public int ProjectCount()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             // Get solution service
             IVsSolution solutionService = (IVsSolution)VsIdeTestHostContext.ServiceProvider.GetService(typeof(IVsSolution));
             object projectCount;
@@ -280,6 +288,8 @@ namespace Microsoft.VsSDK.IntegrationTestLibrary
         /// <returns>New project.</returns>
         public void CreateProjectFromTemplate(string projectName, string templateName, string language, bool exclusive)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             DTE dte = (DTE)VsIdeTestHostContext.ServiceProvider.GetService(typeof(DTE));
 
             Solution2 sol = dte.Solution as Solution2;
@@ -304,6 +314,8 @@ namespace Microsoft.VsSDK.IntegrationTestLibrary
         /// <returns></returns>
         public ProjectItem AddNewItemFromVsTemplate(ProjectItems parent, string templateName, string language, string name)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (parent == null)
                 throw new ArgumentException("project");
             if (name == null)
@@ -326,6 +338,8 @@ namespace Microsoft.VsSDK.IntegrationTestLibrary
         /// <param name="documentMoniker">for filebased documents this is the full path to the document</param>
         public void SaveDocument(string documentMoniker)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             // Get document cookie and hierarchy for the file
             IVsRunningDocumentTable runningDocumentTableService = (IVsRunningDocumentTable)VsIdeTestHostContext.ServiceProvider.GetService(typeof(IVsRunningDocumentTable));
             uint docCookie;
@@ -347,6 +361,8 @@ namespace Microsoft.VsSDK.IntegrationTestLibrary
 
         public void CloseInEditorWithoutSaving(string fullFileName)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             // Get the RDT service
             IVsRunningDocumentTable runningDocumentTableService = (IVsRunningDocumentTable)VsIdeTestHostContext.ServiceProvider.GetService(typeof(IVsRunningDocumentTable));
             Assert.IsNotNull(runningDocumentTableService, "Failed to get the Running Document Table Service");
@@ -379,6 +395,8 @@ namespace Microsoft.VsSDK.IntegrationTestLibrary
         #region Methods: Handling Toolwindows
         public bool CanFindToolwindow(Guid persistenceGuid)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             IVsUIShell uiShellService = VsIdeTestHostContext.ServiceProvider.GetService(typeof(SVsUIShell)) as IVsUIShell;
             Assert.IsNotNull(uiShellService);
             IVsWindowFrame windowFrame;
@@ -392,6 +410,8 @@ namespace Microsoft.VsSDK.IntegrationTestLibrary
         #region Methods: Loading packages
         public IVsPackage LoadPackage(Guid packageGuid)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             IVsShell shellService = (IVsShell)VsIdeTestHostContext.ServiceProvider.GetService(typeof(SVsShell));
             IVsPackage package;
             shellService.LoadPackage(ref packageGuid, out package);
@@ -405,6 +425,8 @@ namespace Microsoft.VsSDK.IntegrationTestLibrary
         /// </summary>
         public void ExecuteCommand(CommandID cmd)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             object Customin = null;
             object Customout = null;
             string guidString = cmd.Guid.ToString("B").ToUpper();

--- a/src/Ankh.VS.IntegrationTest/PackageTest.cs
+++ b/src/Ankh.VS.IntegrationTest/PackageTest.cs
@@ -64,6 +64,7 @@ namespace IntegrationTestProject
         {
             UIThreadInvoker.Invoke((ThreadInvoker)delegate()
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
 
                 //Get the Shell Service
                 IVsShell shellService = VsIdeTestHostContext.ServiceProvider.GetService(typeof(SVsShell)) as IVsShell;

--- a/src/Ankh.VS.IntegrationTest/SignOff-Tests/CPPProjectTests.cs
+++ b/src/Ankh.VS.IntegrationTest/SignOff-Tests/CPPProjectTests.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Text;
 using System.Collections.Generic;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VsSDK.IntegrationTestLibrary;
 using Microsoft.VSSDK.Tools.VsIdeTesting;
@@ -63,7 +64,7 @@ namespace IntegrationTests
         // [ClassCleanup()]
         // public static void MyClassCleanup() { }
         //
-        // Use TestInitialize to run code before running each test 
+        // Use TestInitialize to run code before running each test
         // [TestInitialize()]
         // public void MyTestInitialize() { }
         //
@@ -79,6 +80,8 @@ namespace IntegrationTests
         {
             UIThreadInvoker.Invoke((ThreadInvoker)delegate()
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
+
                 //Solution and project creation parameters
                 string solutionName = "CPPWinApp";
                 string projectName = "CPPWinApp";

--- a/src/Ankh.VS.IntegrationTest/SignOff-Tests/CSharpProjectTests.cs
+++ b/src/Ankh.VS.IntegrationTest/SignOff-Tests/CSharpProjectTests.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Text;
 using System.Collections.Generic;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VsSDK.IntegrationTestLibrary;
 using Microsoft.VSSDK.Tools.VsIdeTesting;
@@ -77,6 +78,8 @@ namespace IntegrationTests
         {
             UIThreadInvoker.Invoke((ThreadInvoker)delegate()
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
+
                 TestUtils testUtils = new TestUtils();
 
                 testUtils.CreateEmptySolution(TestContext.TestDir, "CSWinApp");

--- a/src/Ankh.VS.IntegrationTest/SignOff-Tests/SolutionTests.cs
+++ b/src/Ankh.VS.IntegrationTest/SignOff-Tests/SolutionTests.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Text;
 using System.Collections.Generic;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VSSDK.Tools.VsIdeTesting;
@@ -61,6 +62,8 @@ namespace IntegrationTests
         {
             UIThreadInvoker.Invoke((ThreadInvoker)delegate()
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
+
                 TestUtils testUtils = new TestUtils();
                 testUtils.CloseCurrentSolution(__VSSLNSAVEOPTIONS.SLNSAVEOPT_NoSave);
                 testUtils.CreateEmptySolution(TestContext.TestDir, "EmptySolution");

--- a/src/Ankh.VS.IntegrationTest/SignOff-Tests/VBProjectTests.cs
+++ b/src/Ankh.VS.IntegrationTest/SignOff-Tests/VBProjectTests.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Text;
 using System.Collections.Generic;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VsSDK.IntegrationTestLibrary;
 using Microsoft.VSSDK.Tools.VsIdeTesting;
@@ -78,6 +79,8 @@ namespace IntegrationTests
         {
             UIThreadInvoker.Invoke((ThreadInvoker)delegate()
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
+
                 //Solution and project creation parameters
                 string solutionName = "VBWinApp";
                 string projectName = "VBWinApp";

--- a/src/Ankh.VS.IntegrationTest/SignOff-Tests/VBProjectTestsWithReload.cs
+++ b/src/Ankh.VS.IntegrationTest/SignOff-Tests/VBProjectTestsWithReload.cs
@@ -18,6 +18,7 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using EnvDTE;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VsSDK.IntegrationTestLibrary;
@@ -81,6 +82,8 @@ namespace IntegrationTests
 
         internal void ReloadProject(int n)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             DTE dte = (DTE)VsIdeTestHostContext.ServiceProvider.GetService(typeof(DTE));
 
             Project proj = dte.Solution.Projects.Item(1);
@@ -113,6 +116,8 @@ namespace IntegrationTests
         {
             UIThreadInvoker.Invoke((ThreadInvoker)delegate()
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
+
                 //Solution and project creation parameters
                 string solutionName = "VBWinApp";
                 string projectName = "VBWinApp";

--- a/src/Ankh.VS.UnitTest/CommandRouting/CommandRoutingTest.cs
+++ b/src/Ankh.VS.UnitTest/CommandRouting/CommandRoutingTest.cs
@@ -23,6 +23,7 @@ using Ankh.Commands;
 using Ankh;
 using AnkhSvn_UnitTestProject.Mocks;
 using Ankh.Selection;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Ankh.UI.Services;
 using Ankh.UI;
@@ -67,6 +68,8 @@ namespace AnkhSvn_UnitTestProject.CommandRouting
         [SetUp]
         public void Initialize()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             // Create the package
             IVsPackage package = new AnkhSvnPackage() as IVsPackage;
             Assert.IsNotNull(package, "The object does not implement IVsPackage");

--- a/src/Ankh.VS.UnitTest/Helpers/CommandExecutor.cs
+++ b/src/Ankh.VS.UnitTest/Helpers/CommandExecutor.cs
@@ -18,6 +18,7 @@ using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using OLEConstants = Microsoft.VisualStudio.OLE.Interop.Constants;
 using Ankh;
@@ -28,6 +29,8 @@ namespace AnkhSvn_UnitTestProject.Helpers
     {
         public static void ExecuteCommand(IVsPackage package, AnkhCommand command)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             Guid cmdId = AnkhId.CommandSetGuid;
             int hr = ((IOleCommandTarget)package).Exec(ref cmdId, (uint)command, (uint)OLECMDEXECOPT.OLECMDEXECOPT_DODEFAULT, IntPtr.Zero, IntPtr.Zero);
             if (hr == VSErr.OLECMDERR_E_DISABLED)

--- a/src/Ankh.VS.UnitTest/Helpers/ServiceProviderHelper.cs
+++ b/src/Ankh.VS.UnitTest/Helpers/ServiceProviderHelper.cs
@@ -17,6 +17,7 @@
 using System;
 using Microsoft.VsSDK.UnitTestLibrary;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using System.Collections.Generic;
 
@@ -60,6 +61,8 @@ namespace AnkhSvn_UnitTestProject.Helpers
 
         public static IDisposable SetSite(IVsPackage package)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             Assert.AreEqual(0, package.SetSite(serviceProvider), "SetSite did not return S_OK");
             return null;// new ServiceProviderHelper();
         }

--- a/src/Ankh.VS.UnitTest/MenuItemTests/MenuItemCallback.cs
+++ b/src/Ankh.VS.UnitTest/MenuItemTests/MenuItemCallback.cs
@@ -54,6 +54,8 @@ namespace UnitTestProject.MenuItemTests
         [SetUp]
         public void SetUp()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             // Create the package
             package = new AnkhSvnPackage();
 
@@ -93,7 +95,7 @@ namespace UnitTestProject.MenuItemTests
             ServiceProviderHelper.DisposeServices();
         }
         /// <summary>
-        /// Verify that a new menu command object gets added to the OleMenuCommandService. 
+        /// Verify that a new menu command object gets added to the OleMenuCommandService.
         /// This action takes place In the Initialize method of the Package object
         /// </summary>
         [Test]

--- a/src/Ankh.VS.UnitTest/Mocks/VsShellMock.cs
+++ b/src/Ankh.VS.UnitTest/Mocks/VsShellMock.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio;
 using Moq;
@@ -27,6 +28,8 @@ namespace AnkhSvn_UnitTestProject.Mocks
     {
         public static IVsShell GetInstance()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             var shell = new Mock<SVsShell>().As<IVsShell2>().As<IVsShell>();
 
             object r;

--- a/src/Ankh.VS.UnitTest/PackageTest.cs
+++ b/src/Ankh.VS.UnitTest/PackageTest.cs
@@ -39,6 +39,7 @@ using Ankh.Scc;
 using NUnit.Framework;
 using Moq;
 using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.OLE.Interop;
 
@@ -56,6 +57,8 @@ namespace UnitTestProject
         [Test]
         public void IsIVsPackage()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             AnkhSvnPackage package = new AnkhSvnPackage();
             Assert.IsNotNull(package as IVsPackage, "The object does not implement IVsPackage");
         }
@@ -63,6 +66,8 @@ namespace UnitTestProject
         [Test]
         public void SetSite()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             // Create the package
             IVsPackage package = new AnkhSvnPackage() as IVsPackage;
             Assert.IsNotNull(package, "The object does not implement IVsPackage");

--- a/src/Ankh.VS/Selection/AnkhCommandService.cs
+++ b/src/Ankh.VS/Selection/AnkhCommandService.cs
@@ -357,6 +357,8 @@ namespace Ankh.Services
 
         void TryRelease(object v)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (_delayed)
                 TryReleaseDelayed();
 
@@ -366,6 +368,8 @@ namespace Ankh.Services
 
         void PostCheck()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             AnkhAction pt = delegate()
             {
                 Thread.Sleep(50);

--- a/src/Ankh/Commands/ItemDelete.cs
+++ b/src/Ankh/Commands/ItemDelete.cs
@@ -45,6 +45,8 @@ namespace Ankh.Commands
 
         public override void OnExecute(CommandEventArgs e)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             List<SvnItem> toDelete = new List<SvnItem>(e.Selection.GetSelectedSvnItems(true));
 
             AnkhMessageBox mb = new AnkhMessageBox(e.Context);

--- a/src/Ankh/Commands/OpenFromSubversion.cs
+++ b/src/Ankh/Commands/OpenFromSubversion.cs
@@ -15,6 +15,7 @@
 //  limitations under the License.
 
 using System;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio;
 using Ankh.UI.RepositoryOpen;
@@ -44,6 +45,8 @@ namespace Ankh.Commands
 
         public override void OnExecute(CommandEventArgs e)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             Uri selectedUri = null;
             Uri rootUri = null;
 
@@ -254,6 +257,8 @@ namespace Ankh.Commands
 
         private static void OpenSolution(CommandEventArgs e, CheckoutProject dlg)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             IVsSolution2 sol = e.GetService<IVsSolution2>(typeof(SVsSolution));
 
             if (sol != null)

--- a/src/Ankh/Commands/OpenInVisualStudio.cs
+++ b/src/Ankh/Commands/OpenInVisualStudio.cs
@@ -55,6 +55,8 @@ namespace Ankh.Commands
 
         public override void OnExecute(CommandEventArgs e)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             AnkhMessageBox mb = new AnkhMessageBox(e.Context);
 
             // Cache items to avoid problems when selection changes by opening editor

--- a/src/Ankh/Commands/OpenInXExplorer.cs
+++ b/src/Ankh/Commands/OpenInXExplorer.cs
@@ -57,6 +57,8 @@ namespace Ankh.Commands
 
         public override void OnExecute(CommandEventArgs e)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             SvnItem node = EnumTools.GetFirst(e.Selection.GetSelectedSvnItems(false));
 
             IAnkhCommandService cmd = e.GetService<IAnkhCommandService>();

--- a/src/Ankh/Services/AnkhDiff.cs
+++ b/src/Ankh/Services/AnkhDiff.cs
@@ -20,6 +20,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Text.RegularExpressions;
 using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using SharpSvn;
 
@@ -66,6 +67,8 @@ namespace Ankh.Services
 
         public bool RunDiff(AnkhDiffArgs args)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (args == null)
                 throw new ArgumentNullException("args");
             else if (!args.Validate())
@@ -151,6 +154,8 @@ namespace Ankh.Services
 
         public bool RunMerge(AnkhMergeArgs args)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (args == null)
                 throw new ArgumentNullException("args");
             else if (!args.Validate())
@@ -230,6 +235,8 @@ namespace Ankh.Services
 
         public bool RunPatch(AnkhPatchArgs args)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (args == null)
                 throw new ArgumentNullException("args");
             else if (!args.Validate())
@@ -320,6 +327,8 @@ namespace Ankh.Services
             public DiffToolMonitor(IAnkhServiceProvider context, string monitor, bool monitorDir, int[] resolvedExitCodes)
                 : base(context)
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
+
                 if (string.IsNullOrEmpty(monitor))
                     throw new ArgumentNullException("monitor");
                 else if (!SvnItem.IsValidPath(monitor))
@@ -367,6 +376,8 @@ namespace Ankh.Services
 
             public void Dispose()
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
+
                 if (_cookie != 0)
                 {
                     uint ck = _cookie;
@@ -410,6 +421,8 @@ namespace Ankh.Services
 
             void OnExited(object sender, EventArgs e)
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
+
                 Process process = sender as Process;
                 IAnkhCommandService cmd = GetService<IAnkhCommandService>();
 
@@ -450,6 +463,8 @@ namespace Ankh.Services
 
             public int FilesChanged(uint cChanges, string[] rgpszFile, uint[] rggrfChange)
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
+
                 if (rgpszFile == null)
                     return VSErr.E_POINTER;
 
@@ -499,7 +514,7 @@ namespace Ankh.Services
             else if (args == null)
                 throw new ArgumentNullException("args");
 
-            // Ok: We received a string with a program and arguments and windows 
+            // Ok: We received a string with a program and arguments and windows
             // wants a program and arguments separated. Let's find the program before substituting
 
             reference = reference.TrimStart();
@@ -597,6 +612,8 @@ namespace Ankh.Services
 
             public string Replace(Match match)
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
+
                 string key;
                 string value;
                 bool vsStyle = true;
@@ -617,7 +634,7 @@ namespace Ankh.Services
                         isTrue = !string.IsNullOrEmpty(value);
 
                     value = match.Groups[isTrue ? "ifbody" : "elsebody"].Value ?? "";
-                    
+
                     value = value.Replace("''", "'").Replace("\"\"", "\"");
 
                     return _diff.SubstituteArguments(value, _diffArgs, _toolMode);
@@ -664,6 +681,8 @@ namespace Ankh.Services
 
             bool TryGetValue(string key, bool vsStyle, string arg, out string value)
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
+
                 if (key == null)
                     throw new ArgumentNullException("key");
 

--- a/src/Ankh/Services/AnkhHelpService.cs
+++ b/src/Ankh/Services/AnkhHelpService.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Text;
 using Ankh.UI;
 using System.Globalization;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio;
 using System.Windows.Forms;
@@ -36,6 +37,8 @@ namespace Ankh.Services
 
         public void RunHelp(VSDialogForm form)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             UriBuilder ub = new UriBuilder("http://svc.ankhsvn.net/svc/go/");
             ub.Query = string.Format("t=dlgHelp&v={0}&l={1}&dt={2}", GetService<IAnkhPackage>().UIVersion, CultureInfo.CurrentUICulture.LCID, Uri.EscapeUriString(form.DialogHelpTypeName));
 
@@ -62,6 +65,8 @@ namespace Ankh.Services
 
         public void RunHelp(IAnkhControlWithHelp control)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             UriBuilder ub = new UriBuilder("http://svc.ankhsvn.net/svc/go/");
             ub.Query = string.Format("t=ctrlHelp&v={0}&l={1}&dt={2}", GetService<IAnkhPackage>().UIVersion, CultureInfo.CurrentUICulture.LCID, Uri.EscapeUriString(control.DialogHelpTypeName));
 

--- a/src/Ankh/Services/ConfigService.cs
+++ b/src/Ankh/Services/ConfigService.cs
@@ -20,6 +20,7 @@ using System.Collections;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.Win32;
 
@@ -132,7 +133,7 @@ namespace Ankh.Configuration
                 foreach (PropertyDescriptor pd in TypeDescriptor.GetProperties(config))
                 {
                     string value = reg.GetValue(pd.Name, null) as string;
-                    
+
                     if (pd.Name == "DiffExePaths")
                     {
                         RegistryKey diffRegKey = OpenHKCUKey("Configuration");
@@ -235,7 +236,7 @@ namespace Ankh.Configuration
                                 reg.CreateSubKey(pd.Name);
                                 RegistryKey extToolReg = OpenHKCUKey("Configuration");
                                 extToolReg = extToolReg.OpenSubKey(pd.Name, true);
-                                
+
                                 if (extToolReg != null)
                                 {
                                     foreach (string extToolDef in extToolReg.GetValueNames())
@@ -470,6 +471,8 @@ namespace Ankh.Configuration
 
         public RegistryKey OpenVSInstanceKey(string name)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             RegistryKey rootKey = null;
             if (VSVersion.VS2005)
             {
@@ -514,7 +517,9 @@ namespace Ankh.Configuration
 
 		public RegistryKey OpenVSUserKey(string name)
 		{
-			RegistryKey rootKey = null;
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            RegistryKey rootKey = null;
 			if (VSVersion.VS2005)
 			{
 				ILocalRegistry3 lr3 = GetService<ILocalRegistry3>(typeof(SLocalRegistry));

--- a/src/Ankh/Services/SolutionSettings.cs
+++ b/src/Ankh/Services/SolutionSettings.cs
@@ -22,6 +22,7 @@ using System.Runtime.InteropServices;
 using System.Security;
 using System.Text.RegularExpressions;
 using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.Win32;
 using SharpSvn;
@@ -44,6 +45,8 @@ namespace Ankh.Settings
         public SolutionSettings(IAnkhServiceProvider context)
             : base(context)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             IVsShell shell = GetService<IVsShell>(typeof(SVsShell));
 
             if (shell == null)
@@ -230,7 +233,7 @@ namespace Ankh.Settings
 
         private bool LoadSolutionProperties(SettingsCache cache, SvnItem item)
         {
-            // Subversion loads all properties in memory at once; loading them 
+            // Subversion loads all properties in memory at once; loading them
             // all is always faster than loading a few
             // We must change this algorithm if Subversions implementation changes
 
@@ -291,7 +294,7 @@ namespace Ankh.Settings
 
         private void LoadRootProperties(SettingsCache cache, SvnItem item)
         {
-            // Subversion loads all properties in memory at once; loading them 
+            // Subversion loads all properties in memory at once; loading them
             // all at once is always faster than loading a few
             using (SvnClient client = GetService<ISvnClientPool>().GetNoUIClient())
             {
@@ -516,6 +519,8 @@ namespace Ankh.Settings
         {
             get
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
+
                 if (_allProjectTypesFilter != null)
                     return _allProjectTypesFilter;
 
@@ -537,6 +542,8 @@ namespace Ankh.Settings
         {
             get
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
+
                 if (_projectFilterName != null)
                     return _projectFilterName;
 
@@ -557,6 +564,8 @@ namespace Ankh.Settings
         {
             get
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
+
                 IVsShell shell = GetService<IVsShell>(typeof(SVsShell));
 
                 if (shell != null)
@@ -580,6 +589,8 @@ namespace Ankh.Settings
         {
             get
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
+
                 IVsShell shell = GetService<IVsShell>(typeof(SVsShell));
 
                 if (shell != null)
@@ -746,6 +757,8 @@ namespace Ankh.Settings
         {
             get
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
+
                 if (_solutionFilter != null)
                     return _solutionFilter;
 
@@ -763,7 +776,7 @@ namespace Ankh.Settings
                         _solutionFilter = "*" + (string)filter;
                     }
                 }
-               
+
                 return _solutionFilter;
             }
         }
@@ -772,16 +785,22 @@ namespace Ankh.Settings
 
         public void OpenProjectFile(string projectFile)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             OpenOrAddProjectFile(projectFile, false);
         }
 
         public void AddProjectFile(string projectFile)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             OpenOrAddProjectFile(projectFile, true);
         }
 
         public void OpenOrAddProjectFile(string projectFile, bool add)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (string.IsNullOrEmpty(projectFile))
                 throw new ArgumentNullException("projectFile");
 

--- a/src/Ankh/Services/ThemingService.cs
+++ b/src/Ankh/Services/ThemingService.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using System.Windows.Forms.Design;
 using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
 using Ankh.UI;
@@ -114,6 +115,8 @@ namespace Ankh.Services
 
         public bool TryGetIcon(string path, out IntPtr hIcon)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             hIcon = IntPtr.Zero;
 
             if (_giff == null)


### PR DESCRIPTION
Get rid of the warning VSTHRD010 in more projects by introducing ThrowIfNotOnUIThread into relevant properties and methods. Not yet tested.